### PR TITLE
Prevents multiple menus from being opend at once

### DIFF
--- a/MonthPicker.js
+++ b/MonthPicker.js
@@ -31,6 +31,7 @@ http://www.gnu.org/licenses/old-licenses/lgpl-2.1.txt.
         };
     var $noop = $.noop;
     var $datepicker = $.datepicker;
+    var _opendInstance = null;
     
     function _makeDefaultButton(options) {
 	    // this refers to the associated input field.
@@ -376,6 +377,11 @@ http://www.gnu.org/licenses/old-licenses/lgpl-2.1.txt.
                 return false;
             }
             
+            // If there is an open menu close it first.
+            if (_opendInstance) {
+                _opendInstance.Close(event);
+            }
+
             var _selectedYear = this.GetSelectedYear();
             if (_elem.data(this._enum._overrideStartYear) !== void 0) {
                 this._setPickerYear(this.options.StartYear);
@@ -410,6 +416,7 @@ http://www.gnu.org/licenses/old-licenses/lgpl-2.1.txt.
                 _elem.focus();
                 
                 this._visible = true;
+                _opendInstance = this;
             }
             
             return false;
@@ -442,6 +449,7 @@ http://www.gnu.org/licenses/old-licenses/lgpl-2.1.txt.
                 }
                 
                 this._visible = false;
+                _opendInstance = null;
             }
         },
 


### PR DESCRIPTION
This is a fix for #19 

It prevents multiple menu instances from being opened at the same time by keeping a reference to the opened  menu in the plugin's closure and calls the Close() method (just on the open instance).

IMPORTANT: I'm pushing this from my work computer which doesn't have node.js installed please run grunt and produce a minified version.

This is a temporary fix that I intend to replace in 2.6 with having a singleton menu (one shared instance of the menu for all plugin instances).

I will discuss the singleton menu it an issue dedicated to the 2.6 release.